### PR TITLE
Also replace %b in the DragInitCmd and DragEndCmd binding calls.

### DIFF
--- a/library/tkdnd.tcl
+++ b/library/tkdnd.tcl
@@ -303,6 +303,7 @@ proc ::tkdnd::_init_drag { button source state rootX rootY X Y } {
     set cmd [string map [list %W [list $source] \
                               %X $rootX %Y $rootY %x $X %y $Y \
                               %S $state  %e <<DragInitCmd>> %A \{\} %% % \
+                              %b \{$button\} \
                               %t \{[bind $source <<DragSourceTypes>>]\}] $cmd]
     set code [catch {uplevel \#0 $cmd} info options]
     # puts "CODE: $code ---- $info"
@@ -384,6 +385,7 @@ proc ::tkdnd::_end_drag { button source target action type data result
   if {[string length $cmd]} {
     set cmd [string map [list %W [list $source] \
                               %X $rootX %Y $rootY %x $X %y $Y %% % \
+                              %b \{$button\} \
                               %S $state %e <<DragEndCmd>> %A \{$action\}] $cmd]
     set info [uplevel \#0 $cmd]
     # if { $info != "" } {


### PR DESCRIPTION
This PR also replaces `%b` (the pressed mouse button) in the `DragInitCmd` and `DragEndCmd` calls.

Background:

in my application the DnD mouse button is configurable during run-time (you can select either the left or right mouse button).
To implement this via TkDND, I register all DnD sources twice and actually check for the correct DnD mouse button in `dnd_init_handler`, e.g. something like

```
tkdnd::drag_source register $w {DND_Text} 1
tkdnd::drag_source register $w {DND_Text} 3
bind $w <<DragInitCmd>> [list dnd_init_handler %W %b ...]
...
proc dnd_init_handler {w b ...} {
    if {![is_configured_dnd_button $b]} {
        return {refuse_drop}
    }
    ....
}
```