### PR TITLE
Use 'return -code error ...' instead of 'error ...'

### DIFF
--- a/library/tkdnd_unix.tcl
+++ b/library/tkdnd_unix.tcl
@@ -149,7 +149,7 @@ proc xdnd::GetPositionData { drop_target typelist time } {
 # ----------------------------------------------------------------------------
 proc xdnd::GetDroppedData { _drag_source _drop_target _common_drag_source_types time } {
   if {![llength $_common_drag_source_types]} {
-    error "no common data types between the drag source and drop target widgets"
+    return -code error "no common data types between the drag source and drop target widgets"
   }
   ## Is drag source in this application?
   if {[catch {winfo pathname -displayof $_drop_target $_drag_source} p]} {


### PR DESCRIPTION
`xdnd::GetDroppedData` uses `error` to report back an exceptional situation: there's no common DND data type; this situation also occurs when dragging some object over a non-DND-aware widget within a Tk application => this `error` statement is called often in a normal application. 

`xdnd::GetDroppedData`  is used via `xdnd::GetPositionData` in a `catch` block within `xdnd::HandleXdndPosition`.

If your application uses a custom error handler by redefining `error`, those `error` calls end up in the custom error handler, although these are not really error situations, but normal behaviour.

=> It would be better to use `return -code error ...` in this case.