### PR TITLE
Remove "windows" windowingsystem check

### DIFF
--- a/library/tkdnd.tcl
+++ b/library/tkdnd.tcl
@@ -123,8 +123,7 @@ namespace eval ::tkdnd {
       x11 {
         set _windowingsystem x11
       }
-      win32 -
-      windows {
+      win32 {
         set _windowingsystem windows
       }
       aqua  {


### PR DESCRIPTION
Ever since `[tk windowingsystem]` was added in tcltk/tk@5ccf903c983e, `"windows"` has not been one of the possible return values, so only check for `"win32"` instead.

Further cleanup is possible, but I would like to check how much is desirable first. I would suggest always checking `[tk windowingsystem]` directly and doing away with the `$::tkdnd::_windowingsystem` variable.