### PR TITLE
Adds support for Tcl 9

### DIFF
--- a/demos/dndSpy.tcl
+++ b/demos/dndSpy.tcl
@@ -6,7 +6,7 @@
 ## This file implements a drop target that is able to accept any type dropped.
 ##
 ## Check Tk version:
-package require Tk 8.3
+package require Tk 8.3-
 
 if {$::tcl_version == "8.3" && ![package vsatisfies $::tcl_patchLevel 8.3.3]} {
     tk_messageBox -type ok -icon error \

--- a/library/tkdnd.tcl
+++ b/library/tkdnd.tcl
@@ -534,5 +534,21 @@ proc ::tkdnd::urn_unquote {url} {
     set start [incr last]
   }
   append result [string range $url $start end]
-  return [encoding convertfrom utf-8 $result]
+  return [from_encoding utf-8 $result]
 };# tkdnd::urn_unquote
+
+if {[package vsatisfies [package require Tcl] 9]} {
+    proc ::tkdnd::to_encoding {enc str} {
+        encoding convertto -profile replace $enc $str
+    }
+    proc ::tkdnd::from_encoding {enc data} {
+        encoding convertfrom -profile replace $enc $data
+    }
+} else {
+    proc ::tkdnd::to_encoding {enc str} {
+        encoding convertto $enc $str
+    }
+    proc ::tkdnd::from_encoding {enc data} {
+        encoding convertfrom $enc $data
+    }
+}

--- a/library/tkdnd_unix.tcl
+++ b/library/tkdnd_unix.tcl
@@ -231,7 +231,7 @@ proc xdnd::normalise_data { type data } {
     STRING - UTF8_STRING - TEXT - COMPOUND_TEXT {return $data}
     text/html {
       if {[catch {
-            encoding convertfrom unicode $data
+            ::tkdnd::from_encoding unicode $data
            } string]} {
         set string $data
       }
@@ -241,7 +241,7 @@ proc xdnd::normalise_data { type data } {
     text/plain\;charset=utf-8 -
     text/plain {
       if {[catch {
-            encoding convertfrom utf-8 [tkdnd::bytes_to_string $data]
+            ::tkdnd::from_encoding utf-8 [tkdnd::bytes_to_string $data]
            } string]} {
         set string $data
       }
@@ -249,7 +249,7 @@ proc xdnd::normalise_data { type data } {
     }
     text/uri-list* {
       if {[catch {
-            encoding convertfrom utf-8 [tkdnd::bytes_to_string $data]
+            ::tkdnd::from_encoding utf-8 [tkdnd::bytes_to_string $data]
           } string]} {
         set string $data
       }
@@ -800,7 +800,7 @@ proc xdnd::_SendData {type offset bytes args} {
     ## Prepare the data to be transferred...
     switch -glob $type {
       text/plain* - UTF8_STRING - STRING - TEXT - COMPOUND_TEXT {
-        binary scan [encoding convertto utf-8 $typed_data] \
+        binary scan [::tkdnd::to_encoding utf-8 $typed_data] \
                     c* _dodragdrop_transfer_data
         set _dodragdrop_transfer_data \
            [_convert_to_unsigned $_dodragdrop_transfer_data $format]
@@ -813,7 +813,7 @@ proc xdnd::_SendData {type offset bytes args} {
             default   {lappend files file://$file}
           }
         }
-        binary scan [encoding convertto utf-8 "[join $files \r\n]\r\n"] \
+        binary scan [::tkdnd::to_encoding utf-8 "[join $files \r\n]\r\n"] \
                     c* _dodragdrop_transfer_data
         set _dodragdrop_transfer_data \
            [_convert_to_unsigned $_dodragdrop_transfer_data $format]
@@ -849,7 +849,7 @@ proc xdnd::_SendData {type offset bytes args} {
   set data [lrange $_dodragdrop_transfer_data $offset [expr {$offset+$bytes-1}]]
   switch $format {
     8  {
-      set data [encoding convertfrom utf-8 [binary format c* $data]]
+      set data [::tkdnd::from_encoding utf-8 [binary format c* $data]]
     }
     16 {
       variable _dodragdrop_selection_requestor

--- a/library/tkdnd_windows.tcl
+++ b/library/tkdnd_windows.tcl
@@ -161,7 +161,7 @@ proc olednd::normalise_data { type data } {
   switch [lindex [::tkdnd::generic::platform_independent_type $type] 0] {
     DND_Text   {return $data}
     DND_Files  {return $data}
-    DND_HTML   {return [encoding convertfrom utf-8 $data]}
+    DND_HTML   {return [::tkdnd::from_encoding utf-8 $data]}
     default    {return $data}
   }
 }; # olednd::normalise_data

--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -171,7 +171,7 @@ static CLIP_FORMAT_STRING_TABLE ClipboardFormatBook[] = {
 #if TCL_UTF_MAX < 4
 // WCHAR string -> Tcl_Obj
 inline Tcl_Obj *ObjFromWinString(const WCHAR *pWS) {
-  return Tcl_NewUnicodeObj(pWS, -1);
+  return Tcl_NewUnicodeObj((Tcl_UniChar *)pWS, -1);
 }
 
 // ObjToWinStringDS - not defined
@@ -195,7 +195,7 @@ inline std::wstring ObjToWString(Tcl_Obj *pObj) {
   // Note this returns any embedded nuls in Tcl_Obj as well!
   int len;
   Tcl_UniChar *p = Tcl_GetUnicodeFromObj(pObj, &len);
-  return std::wstring(p, len);
+  return std::wstring((wchar_t *)p, len);
 }
 
 // WCHAR string -> HGLOBAL. Panics on memory allocation failure.
@@ -1124,7 +1124,7 @@ private:
           WCHAR *wstr = (WCHAR *) GlobalLock(StgMed.hGlobal);
           Tcl_DStringInit(&ds);
 #if TCL_UTF_MAX < 4
-          Tcl_UniCharToUtfDString(wstr, -1, &ds);
+          Tcl_UniCharToUtfDString((Tcl_UniChar *)wstr, -1, &ds);
 #else
           Tcl_WCharToUtfDString(wstr, -1, &ds);
 #endif

--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -255,7 +255,7 @@ inline Tcl_Size ObjToWinStringBuffer(Tcl_Obj *pObj, WCHAR *pBuf, Tcl_Size max_le
 inline std::wstring ObjToWString(Tcl_Obj *pObj) {
   Tcl_DString ds;
   Tcl_Size len = ObjToWinStringDS(pObj, &ds);
-   return std::wstring((WCHAR *)Tcl_DStringValue(&ds), len/sizeof(WCHAR));
+   return std::wstring((WCHAR *)Tcl_DStringValue(&ds));
 }
 
 // WCHAR string -> HGLOBAL. Panics on memory allocation failure.
@@ -1124,7 +1124,8 @@ private:
           WCHAR *wstr = (WCHAR *) GlobalLock(StgMed.hGlobal);
           Tcl_DStringInit(&ds);
 #if TCL_UTF_MAX < 4
-          Tcl_UniCharToUtfDString((Tcl_UniChar *)wstr, -1, &ds);
+          /* 8.6 Tcl_UniCharToUtfDString does not accept -1 for length!!!*/
+          Tcl_UniCharToUtfDString((Tcl_UniChar *)wstr, wcslen(wstr), &ds);
 #else
           Tcl_WCharToUtfDString(wstr, -1, &ds);
 #endif

--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -1142,6 +1142,7 @@ private:
           *destPtr = '\0';
 #if TCL_MAJOR_VERSION < 9
           result = Tcl_NewStringObj(Tcl_DStringValue(&ds), Tcl_DStringLength(&ds));
+          Tcl_DStringFree(&ds);
 #else
           result = Tcl_DStringToObj(&ds); // No need for Tcl_DStringFree
 #endif

--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -225,7 +225,7 @@ inline Tcl_Size ObjToWinStringDS(Tcl_Obj *pObj, Tcl_DString *pDS) {
   const char *type_str = Tcl_GetStringFromObj(pObj, &type_len);
   WCHAR *wtype_str;
   Tcl_UtfToWCharDString(type_str, type_len, pDS);
-  return (Tcl_DStringLength(pDS)/sizeof(WCHAR)) - 1;
+  return (Tcl_DStringLength(pDS)/sizeof(WCHAR)); // Not including terminator
 };
 
 // Copy a Tcl_Obj to a WCHAR buffer. Always terminates the buffer.
@@ -245,7 +245,7 @@ inline Tcl_Size ObjToWinStringBuffer(Tcl_Obj *pObj, WCHAR *pBuf, Tcl_Size max_le
 // Always returns non-NULL. HGLOBAL must be GlobalFree'd.
 inline HGLOBAL ObjToWinStringHGLOBAL(Tcl_Obj *pObj) {
   Tcl_DString ds;
-  Tcl_Size len = ObjToWinStringDS(pObj, &ds);
+  Tcl_Size len = ObjToWinStringDS(pObj, &ds); // Does not include terminator
   WCHAR *to;
   HGLOBAL hGlobal = GlobalAlloc(GHND, (len+1) * sizeof(WCHAR));
   if (hGlobal == NULL) {

--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -128,7 +128,9 @@ extern "C" {
 /*****************************************************************************
  * Windows Clipboard formats.
  ****************************************************************************/
-#define STRING_(s) {s,L#s}
+#define WIDEN(x) L##x
+#define WSTRINGIFY(x) WIDEN(#x)
+#define STRING_(s) {s, WSTRINGIFY(s)}
 typedef struct {
   UINT   cfFormat;
   const WCHAR *name;

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -166,7 +166,6 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
   int               status, index, button = 1;
   Tcl_Size          i, type_nu, data_nu, nDataLength;
   char             *ptr;
-  Tcl_UniChar      *unicode, *ptr_u;
   FORMATETC        *m_pfmtetc;
   STGMEDIUM        *m_pstgmed;
   static const char *DropTypes[] = {
@@ -254,21 +253,7 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
       switch ((enum droptypes) index) {
         case TYPE_CF_UNICODETEXT: {
           m_pfmtetc[i].cfFormat = CF_UNICODETEXT;
-          unicode = Tcl_GetUnicodeFromObj(data[i], &nDataLength);
-          buffer_size = (nDataLength+1) * sizeof(Tcl_UniChar);
-          m_pstgmed[i].hGlobal = GlobalAlloc(GHND, buffer_size);
-          if (m_pstgmed[i].hGlobal) {
-            ptr_u = (Tcl_UniChar *) GlobalLock(m_pstgmed[i].hGlobal);
-#if 0
-#ifdef HAVE_STRSAFE_H
-            StringCchCopyW((LPWSTR) ptr_u, buffer_size, (LPWSTR) unicode);
-#else
-            lstrcpyW((LPWSTR) ptr_u, (LPWSTR) unicode);
-#endif
-#endif
-            memcpy(ptr_u, unicode, buffer_size);
-            GlobalUnlock(m_pstgmed[i].hGlobal);
-          }
+          m_pstgmed[i].hGlobal = ObjToWinStringHGLOBAL(data[i]);
           break;
         }
         case TYPE_CF_HTMLFORMAT:

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -145,8 +145,8 @@ int TkDND_RevokeDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
     GlobalUnlock(m_pstgmed[i].hGlobal); \
   }
 
-#define COPY_BYTEARRAY_TO_DATA_OBJECT(type_str) \
-  m_pfmtetc[i].cfFormat = RegisterClipboardFormat(type_str); \
+#define COPY_BYTEARRAY_TO_DATA_OBJECT(wchar_type_str) \
+  m_pfmtetc[i].cfFormat = RegisterClipboardFormatW(wchar_type_str); \
   bytes = Tcl_GetByteArrayFromObj(data[i], &nDataLength); \
   m_pstgmed[i].hGlobal = GlobalAlloc(GHND, nDataLength); \
   if (m_pstgmed[i].hGlobal) { \
@@ -273,13 +273,13 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
         }
         case TYPE_CF_HTMLFORMAT:
         case TYPE_CF_HTML: {
-          COPY_BYTEARRAY_TO_DATA_OBJECT(TEXT("HTML Format"));
+          COPY_BYTEARRAY_TO_DATA_OBJECT(L"HTML Format");
           break;
         }
         case TYPE_CF_RICHTEXTFORMAT:
         case TYPE_CF_RTF:
         case TYPE_CF_RTFTEXT: {
-          COPY_BYTEARRAY_TO_DATA_OBJECT(TEXT("Rich Text Format"));
+          COPY_BYTEARRAY_TO_DATA_OBJECT(L"Rich Text Format");
           break;
         }
         case TYPE_CF_TEXT: {
@@ -360,7 +360,14 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
       }
     } else {
       /* A user defined type? */
-      COPY_BYTEARRAY_TO_DATA_OBJECT(TCL_GETSTRING(type[i]));
+#if TCL_MAJOR_VERSION < 9
+      COPY_BYTEARRAY_TO_DATA_OBJECT(Tcl_GetUnicode(type[i]));
+#else
+      Tcl_DString ds;
+      ObjToWinStringDS(type[i], &ds);
+      COPY_BYTEARRAY_TO_DATA_OBJECT((WCHAR *)Tcl_DStringValue(&ds));
+      Tcl_DStringFree(&ds);
+#endif
       break;
     }
   }; /* for (i = 0; i < type_nu; i++) */

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -269,11 +269,9 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
         }
         case TYPE_CF_HDROP: {
           LPDROPFILES pDropFiles;
-          Tcl_DString ds;
-          Tcl_Obj **File, *native_files_obj = NULL, *obj;
+          Tcl_Obj **File, *native_files_obj = NULL;
           Tcl_Size j, file_nu;
           Tcl_Size size, len;
-          char *native_name;
           WCHAR *CurPosition;
 
           status = Tcl_ListObjGetElements(interp, data[i], &file_nu, &File);

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -372,16 +372,15 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
   delete[] m_pfmtetc;
   delete[] m_pstgmed;
   if (dwResult == DRAGDROP_S_DROP) {
-    char msg[24];
+    const char *msg;
     switch (dwEffect) {
-      case DROPEFFECT_COPY: std::strncpy(msg, "copy", 20); break;
-      case DROPEFFECT_MOVE: std::strncpy(msg, "move", 20); break;
-      case DROPEFFECT_LINK: std::strncpy(msg, "link", 20); break;
+      case DROPEFFECT_COPY: msg = "copy"; break;
+      case DROPEFFECT_MOVE: msg = "move"; break;
+      case DROPEFFECT_LINK: msg = "link"; break;
     }
     Tcl_SetObjResult(interp, Tcl_NewStringObj(msg, -1));
   } else {
-    char msg[24]; std::strncpy(msg, "refuse_drop", 20);
-    Tcl_SetObjResult(interp, Tcl_NewStringObj(msg, -1));
+    Tcl_SetObjResult(interp, Tcl_NewStringObj("refuse_drop", -1));
   }
   return TCL_OK;
 error:

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -39,11 +39,6 @@
  */
 
 #include "OleDND.h"
-#if defined(HAVE_STRSAFE_H) || !defined(NO_STRSAFE_H)
-#include "Strsafe.h"
-#endif
-
-#include <cstring>
 
 #define TKDND_REPORT_ERROR(x) \
     { Tcl_SetObjResult(interp, Tcl_NewStringObj(x, -1)); }

--- a/win/TkDND_OleDND.cpp
+++ b/win/TkDND_OleDND.cpp
@@ -340,7 +340,7 @@ int TkDND_DoDragDropObjCmd(ClientData clientData, Tcl_Interp *interp,
     } else {
       /* A user defined type? */
 #if TCL_MAJOR_VERSION < 9
-      COPY_BYTEARRAY_TO_DATA_OBJECT(Tcl_GetUnicode(type[i]));
+      COPY_BYTEARRAY_TO_DATA_OBJECT((WCHAR *)Tcl_GetUnicode(type[i]));
 #else
       Tcl_DString ds;
       ObjToWinStringDS(type[i], &ds);

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -1,0 +1,53 @@
+#------------------------------------------------------------- -*- makefile -*-
+#
+# Makefile for tkdnd
+#
+# Basic build, test and install (assuming Tcl/Tk installed in c:/tcl)
+#   nmake /f makefile.vc INSTALLDIR=c:\tcl
+#   nmake /f makefile.vc INSTALLDIR=c:\tcl test
+#   nmake /f makefile.vc INSTALLDIR=c:\tcl install
+#
+# For other build options (debug, static etc.),
+# See TIP 477 (https://core.tcl.tk/tips/doc/trunk/tip/477.md) for
+# detailed documentation.
+#
+# See the file "LICENSE" for information on usage and redistribution
+# of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+#
+PROJECT = tkdnd
+PROJECT_REQUIRES_TK = 1
+
+!if [echo DOTVERSION = \> versions.vc] \
+   || [type ..\VERSION >> versions.vc]
+!error *** Could not figure out extension version. Please define DOTVERSION in parent makefile before including rules.vc.
+!endif
+
+!include versions.vc
+
+!include "rules-ext.vc"
+
+PRJ_OBJS = \
+    $(TMP_DIR)\TkDND_OleDND.obj \
+	$(TMP_DIR)\TkDND_Cursors.obj
+
+TKDND_HEADERS = \
+    $(WIN_DIR)\OleDND.h \
+    $(GENERICDIR)\TkDND_Cursors.h
+
+PRJ_DEFINES = -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1 \
+    -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1 \
+    -D_CRT_SECURE_NO_WARNINGS \
+	-D_UNICODE -DUNICODE
+
+PRJ_LIBS = ole32.lib shell32.lib
+
+!include "$(_RULESDIR)\targets.vc"
+
+pkgindex: default-pkgindex-tea
+
+$(TMP_DIR)\TkDND_OleDND.obj: $(WIN_DIR)\TkDND_OleDND.cpp $(TKDND_HEADERS)
+	$(CCPKGCMD) $(WIN_DIR)\TkDND_OleDND.cpp
+
+$(TMP_DIR)\TkDND_Cursors.obj: $(TKDND_HEADERS)
+
+

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -7,6 +7,10 @@
 #   nmake /f makefile.vc INSTALLDIR=c:\tcl test
 #   nmake /f makefile.vc INSTALLDIR=c:\tcl install
 #
+# IMPORTANT: by default, this links dynamically to the C and C++ runtimes.
+# To link statically, pass "nomsvcrt" as part of the OPTS argument. E.g.
+#   nmake /f makefile.vc INSTALLDIR=c:\tcl OPTS=pdbs,nomsvcrt
+#
 # For other build options (debug, static etc.),
 # See TIP 477 (https://core.tcl.tk/tips/doc/trunk/tip/477.md) for
 # detailed documentation.

--- a/win/rules-ext.vc
+++ b/win/rules-ext.vc
@@ -1,0 +1,118 @@
+# This file should only be included in makefiles for Tcl extensions,
+# NOT in the makefile for Tcl itself.
+
+!ifndef _RULES_EXT_VC
+
+# We need to run from the directory the parent makefile is located in.
+# nmake does not tell us what makefile was used to invoke it so parent
+# makefile has to set the MAKEFILEVC macro or we just make a guess and
+# warn if we think that is not the case.
+!if "$(MAKEFILEVC)" == ""
+
+!if exist("$(PROJECT).vc")
+MAKEFILEVC = $(PROJECT).vc
+!elseif exist("makefile.vc")
+MAKEFILEVC = makefile.vc
+!endif
+!endif # "$(MAKEFILEVC)" == ""
+
+!if !exist("$(MAKEFILEVC)")
+MSG = ^
+You must run nmake from the directory containing the project makefile.^
+If you are doing that and getting this message, set the MAKEFILEVC^
+macro to the name of the project makefile.
+!message WARNING: $(MSG)
+!endif
+
+!if "$(PROJECT)" == "tcl"
+!error The rules-ext.vc file is not intended for Tcl itself.
+!endif
+
+# We extract version numbers using the nmakehlp program. For now use
+# the local copy of nmakehlp. Once we locate Tcl, we will use that
+# one if it is newer.
+!if [$(CC) -nologo "nmakehlp.c" -link -subsystem:console > nul]
+!endif
+
+# First locate the Tcl directory that we are working with.
+!ifdef TCLDIR
+
+_RULESDIR = $(TCLDIR:/=\)
+
+!else
+
+# If an installation path is specified, that is also the Tcl directory.
+# Also Tk never builds against an installed Tcl, it needs Tcl sources
+!if defined(INSTALLDIR) && "$(PROJECT)" != "tk"
+_RULESDIR=$(INSTALLDIR:/=\)
+!else
+# Locate Tcl sources
+!if [echo _RULESDIR = \> nmakehlp.out] \
+   || [nmakehlp -L generic\tcl.h >> nmakehlp.out]
+_RULESDIR = ..\..\tcl
+!else
+!include nmakehlp.out
+!endif
+
+!endif # defined(INSTALLDIR)....
+
+!endif # ifndef TCLDIR
+
+# Now look for the targets.vc file under the Tcl root. Note we check this
+# file and not rules.vc because the latter also exists on older systems.
+!if exist("$(_RULESDIR)\lib\nmake\targets.vc") # Building against installed Tcl
+_RULESDIR = $(_RULESDIR)\lib\nmake
+!elseif exist("$(_RULESDIR)\win\targets.vc")   # Building against Tcl sources
+_RULESDIR = $(_RULESDIR)\win
+!else
+# If we have not located Tcl's targets file, most likely we are compiling
+# against an older version of Tcl and so must use our own support files.
+_RULESDIR = .
+!endif
+
+!if "$(_RULESDIR)" != "."
+# Potentially using Tcl's support files. If this extension has its own
+# nmake support files, need to compare the versions and pick newer.
+
+!if exist("rules.vc") # The extension has its own copy
+
+!if [echo TCL_RULES_MAJOR = \> versions.vc] \
+   && [nmakehlp -V "$(_RULESDIR)\rules.vc" RULES_VERSION_MAJOR >> versions.vc]
+!endif
+!if [echo TCL_RULES_MINOR = \>> versions.vc] \
+   && [nmakehlp -V "$(_RULESDIR)\rules.vc" RULES_VERSION_MINOR >> versions.vc]
+!endif
+
+!if [echo OUR_RULES_MAJOR = \>> versions.vc] \
+   && [nmakehlp -V "rules.vc" RULES_VERSION_MAJOR >> versions.vc]
+!endif
+!if [echo OUR_RULES_MINOR = \>> versions.vc] \
+   && [nmakehlp -V "rules.vc" RULES_VERSION_MINOR >> versions.vc]
+!endif
+!include versions.vc
+# We have a newer version of the support files, use them
+!if ($(TCL_RULES_MAJOR) != $(OUR_RULES_MAJOR)) || ($(TCL_RULES_MINOR) < $(OUR_RULES_MINOR))
+_RULESDIR = .
+!endif
+
+!endif # if exist("rules.vc")
+
+!endif # if $(_RULESDIR) != "."
+
+# Let rules.vc know what copy of nmakehlp.c to use.
+NMAKEHLPC = $(_RULESDIR)\nmakehlp.c
+
+# Get rid of our internal defines before calling rules.vc
+!undef TCL_RULES_MAJOR
+!undef TCL_RULES_MINOR
+!undef OUR_RULES_MAJOR
+!undef OUR_RULES_MINOR
+
+!if exist("$(_RULESDIR)\rules.vc")
+!message *** Using $(_RULESDIR)\rules.vc
+!include "$(_RULESDIR)\rules.vc"
+!else
+!error *** Could not locate rules.vc in $(_RULESDIR)
+!endif
+
+!endif # _RULES_EXT_VC


### PR DESCRIPTION
This PR adds support for Tcl 9 and along the way fixes some potential buffer overflows. Demos are functional but before accepting the pull request, you may want to consider the following:

- Only Windows code modified except for Tcl scripts where use of the encoding commands was changed so the replace profile is in effect instead of Tcl 9 default strict mode.
- Non-Unicode builds (_MBCS) not tested and probably will not work. In any case, I do not believe _MBCS will fully work with modern Tcl versions and are completely unnecessary for the NT platform. Win98 is long dead.
- A TIP 477 nmake based build system has been added, partly to match conventions in other extensions but mostly because I could not get the cmake builds to work with Tcl 9 installations. All tests done using this nmake build config. Requires Tcl 8.6.8 or later to build. The existing cmake build continue to work with this PR with 8.6.
- Tested with the demos scripts on Win 10 (Tcl 8.6 and 9.0.0 with both x86 and x64.) Not tested with earlier versions of Tcl (8.4/8.5)
- Version is not changed but probably should be since _MBCS is no longer supported
