### PR TITLE
Make STRING_ macros work with both gcc and MS VC

### DIFF
--- a/win/OleDND.h
+++ b/win/OleDND.h
@@ -129,8 +129,7 @@ extern "C" {
  * Windows Clipboard formats.
  ****************************************************************************/
 #define WIDEN(x) L##x
-#define WSTRINGIFY(x) WIDEN(#x)
-#define STRING_(s) {s, WSTRINGIFY(s)}
+#define STRING_(s) {s, WIDEN(#s)}
 typedef struct {
   UINT   cfFormat;
   const WCHAR *name;


### PR DESCRIPTION
Fix for the bug introduced in Tcl 9 port - https://github.com/petasis/tkdnd/issues/71
The STRING_ macro has been fixed to work with gcc as well as vc++.

Verified all demos work except `custom_cursors` which does not work for me even in previous tkdnd releases on Windows. Combinations tested (Windows only):

VS 2022 x64 with Tcl 9.0.0 (using the TIP 477 nmake, not cmake which does not detect 9.0.0 at least on my system)
VS 2022 x86 with Tcl 8.6.10 (again, using TIP 477 nmake)
MingW64 with Tcl 8.6.10 (to verify gcc using cmake build64.sh)